### PR TITLE
Stop resetting path box

### DIFF
--- a/gui/flyingcarpet/gui.go
+++ b/gui/flyingcarpet/gui.go
@@ -180,20 +180,24 @@ func newWindow(gui *Gui) *widgets.QMainWindow {
 	//////////////////////////////
 
 	t := &fcc.Transfer{}
-
+	// Don't reset selection when clicking radio
 	sendMode.ConnectClicked(func(bool) {
 		sendButton.Show()
 		receiveButton.Hide()
-		t.FileList = nil
-		t.ReceiveDir = ""
-		fileBox.SetText("")
+		// Don't change if it was already set
+		if !t.FileList {
+			t.FileList = nil
+		}
+		fileBox.SetText(t.FileList)
 	})
 	receiveMode.ConnectClicked(func(bool) {
 		receiveButton.Show()
 		sendButton.Hide()
-		t.FileList = nil
-		t.ReceiveDir = getHomePath()
-		fileBox.SetText(getHomePath())
+		// Don't change if it was already set
+		if !t.ReceiveDir {
+			t.ReceiveDir = getHomePath()
+		}
+		fileBox.SetText(t.ReceiveDir)
 	})
 
 	sendButton.ConnectClicked(func(bool) {
@@ -202,7 +206,11 @@ func newWindow(gui *Gui) *widgets.QMainWindow {
 			return
 		}
 		// open dialog
-		fd := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
+		temp_fd := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
+		//Don't change if they click cancel
+		if !(temp_fd in [nil,""]) {
+			fd:= temp_fd
+		}
 		t.FileList = fd.GetOpenFileNames(window, "Select File(s)", "", "", "", 0)
 		if len(t.FileList) == 1 {
 			fileBox.SetText(t.FileList[0])

--- a/gui/flyingcarpet/gui.go
+++ b/gui/flyingcarpet/gui.go
@@ -206,10 +206,10 @@ func newWindow(gui *Gui) *widgets.QMainWindow {
 			return
 		}
 		// open dialog
-		temp_fd := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
+		fd_tmp := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
 		//Don't change if they click cancel
-		if !(temp_fd in [nil,""]) {
-			fd:= temp_fd
+		if fd_tmp != nil {
+			fd:= fd_tmp
 		}
 		t.FileList = fd.GetOpenFileNames(window, "Select File(s)", "", "", "", 0)
 		if len(t.FileList) == 1 {
@@ -220,7 +220,10 @@ func newWindow(gui *Gui) *widgets.QMainWindow {
 	})
 	receiveButton.ConnectClicked(func(bool) {
 		// open dialog
-		fd := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
+		fd_tmp := widgets.NewQFileDialog2(window, "Select Files", getHomePath(), "")
+		if fd_tmp != nil {
+			fd := fd_tmp
+		}
 		t.ReceiveDir = fd.GetExistingDirectory(window, "Select Folder", "", 0)
 		fileBox.SetText(t.ReceiveDir)
 	})

--- a/gui/flyingcarpet/gui.go
+++ b/gui/flyingcarpet/gui.go
@@ -180,6 +180,7 @@ func newWindow(gui *Gui) *widgets.QMainWindow {
 	//////////////////////////////
 
 	t := &fcc.Transfer{}
+	
 	// Don't reset selection when clicking radio
 	sendMode.ConnectClicked(func(bool) {
 		sendButton.Show()


### PR DESCRIPTION
When a radio button gets pressed, or when the user presses cancel on the selection dialog, the selection no longer gets reset